### PR TITLE
Correcting magic link route

### DIFF
--- a/src/PasswordlessClient.ts
+++ b/src/PasswordlessClient.ts
@@ -122,7 +122,7 @@ export class PasswordlessClient implements IPasswordlessClient {
    * @inheritDoc
    */
   sendMagicLink = (request: SendMagicLinkRequest): Promise<void> =>
-    this._httpClient.post("magic-link/send", request);
+    this._httpClient.post("magic-links/send", request);
 
   /**
    * @inheritDoc


### PR DESCRIPTION
Correcting route from `magic-link/send` to `magic-links/send`