### PR TITLE
[BRE-2094] Update CD workflow and add Publish workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,9 +33,7 @@ jobs:
         run: npm run lint
 
   # Attach the CI-built npm bundle to the release so bitwarden/deploy's
-  # publish-passwordless-nodejs.yml can promote it later. This workflow does NOT publish to
-  # npm — that step is manually gated in bitwarden/deploy and runs from the public
-  # publish.yml shim under this repo.
+  # publish-passwordless-nodejs.yml can promote it later.
   attach-build:
     name: Attach npm build to release
     needs: format
@@ -58,9 +56,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Fail fast if the release tag doesn't line up with package.json — the downstream
-      # publish trusts package.json, so a mismatch here would publish a different version
-      # than the release advertises.
       - name: Verify package.json version matches release tag
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,11 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
 name: Node.js Package
 
 on:
   release:
     types:
       - published
+
+permissions: {}
 
 jobs:
   format:
@@ -33,16 +32,17 @@ jobs:
       - name: Run format
         run: npm run lint
 
-  deploy:
-    name: Deploy
-    if: ${{ github.event_name == 'release' }}
+  # Attach the CI-built npm bundle to the release so bitwarden/deploy's
+  # publish-passwordless-nodejs.yml can promote it later. This workflow does NOT publish to
+  # npm — that step is manually gated in bitwarden/deploy and runs from the public
+  # publish.yml shim under this repo.
+  attach-build:
+    name: Attach npm build to release
     needs: format
     runs-on: ubuntu-24.04
 
     permissions:
-      actions: write
-      contents: read
-      id-token: write
+      contents: write
 
     steps:
       - name: Checkout
@@ -58,52 +58,33 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Fail fast if the release tag doesn't line up with package.json — the downstream
+      # publish trusts package.json, so a mismatch here would publish a different version
+      # than the release advertises.
+      - name: Verify package.json version matches release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PKG_VERSION=$(jq -r '.version' package.json)
+          if [[ "$PKG_VERSION" != "$RELEASE_TAG" ]]; then
+            echo "::error::package.json version '${PKG_VERSION}' does not match release tag '${RELEASE_TAG}'"
+            exit 1
+          fi
+
       - name: Run build
         run: npm run build
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: packages
-          path: |
-            dist
-            package.json
-
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
-        with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Get Azure Key Vault secrets
-        id: get-kv-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: gh-org-bitwarden
-          secrets: 'BW-GHAPP-ID,BW-GHAPP-KEY'
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Generate GH App token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
-        id: app-token
-        with:
-          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
-          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
-          owner: bitwarden
-          repositories: passwordless-devops
-
-      - name: Dispatch deployment
+      - name: Zip build
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
-        run: >
-          gh workflow run deploy-passwordless-nodejs
-          --repo bitwarden/passwordless-devops
-          --field repository="${{ github.repository }}"
-          --field run-id="${{ github.run_id }}"
-          --field artifact="packages"
-          --field environment="npm"
-          --field version="${TAG_NAME}"
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          zip -r "passwordless-nodejs-${RELEASE_TAG}-npm-build.zip" dist
+
+      - name: Upload zip as release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release upload "${RELEASE_TAG}" \
+            "passwordless-nodejs-${RELEASE_TAG}-npm-build.zip" \
+            --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+# Inert publish shim for @passwordlessdev/passwordless-nodejs.
+# Do NOT add logic to this file — it is intentionally minimal and managed by BRE.
+
+name: "Passwordless Node.js: Publish"
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish @passwordlessdev/passwordless-nodejs to npm
+    permissions:
+      contents: read
+      id-token: write
+    uses: bitwarden/gh-actions/.github/workflows/_publish-passwordless-nodejs-npm.yml@main
+


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2094](https://bitwarden.atlassian.net/browse/BRE-2094)

## 📔 Objective

This PR updates the CD workflow to build on every push to `main` and upload the bundle as an artifact. The `Passwordless Node.js: Release` workflow in the `deploy` repository will promote the artifact to a GitHub release. The inert Publish workflow was also added as the entry point for the provenance-backed npm publish.

[BRE-2094]: https://bitwarden.atlassian.net/browse/BRE-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ